### PR TITLE
Cache precommit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,21 @@ jobs:
             echo "source /home/circleci/venv/bin/activate" >> $BASH_ENV
 
       - restore_cache:
+          name: Restore venv cache
           keys:
             - &lint-cache-key python-3.12-uv-v3-{{ checksum "requirements/development.txt" }}
+
+      - run:
+          name: Create pre-commit cache key
+          command: |
+            cp .pre-commit-config.yaml pre-commit-cache-key.txt
+            python --version >> pre-commit-cache-key.txt
+
+      - restore_cache:
+          name: Restore pre-commit cache
+          keys:
+            - &precommit-cache-key pre-commit-v2-{{ checksum "pre-commit-cache-key.txt" }}
+            - pre-commit-v2-
 
       - run:
           name: Install dependencies
@@ -31,6 +44,7 @@ jobs:
           command: uv cache dir
 
       - save_cache:
+          name: Save venv cache
           key: *lint-cache-key
           paths:
             - "~/venv/"
@@ -59,6 +73,12 @@ jobs:
             SKIP: ruff-lint,ruff-format,no-commit-to-branch
           command: pre-commit run --all-files
           when: always
+
+      - save_cache:
+          name: Save pre-commit cache
+          key: *precommit-cache-key
+          paths:
+            - "~/.cache/pre-commit"
 
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,6 @@ jobs:
           name: Install dependencies
           command: make dev
 
-      - run:
-          name: Show uv cache directory
-          command: uv cache dir
-
       - save_cache:
           name: Save venv cache
           key: *lint-cache-key


### PR DESCRIPTION
We cache the pre-commit environment to speed up the build.

With Cache:
https://app.circleci.com/pipelines/github/jarshwah/lint-ratchet/23/workflows/7445e7e3-e929-4ef5-ba3b-57b6a48ba5d2/jobs/57

Without Cache:
https://app.circleci.com/pipelines/github/jarshwah/lint-ratchet/22/workflows/d2a825f2-96c1-46aa-bccd-6e04a1881729/jobs/54

Here we see the pre-commit step from from 13s to 2s - with approx 2 seconds of overhead creating/restoring the precommit cache.